### PR TITLE
Add Linux launcher

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,7 @@
+# Contrib
+
+This directory contains community-contributed scripts to be used together with
+DojoTimer.
+
+- [`dojotimer`](dojotimer): this is a helper launcher to start DojoTimer on
+  Linux. See the script for installation and usage instructions.

--- a/contrib/dojotimer
+++ b/contrib/dojotimer
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Helper script to start DojoTimer on Linux.
+#
+# Installation:
+# Copy or symlink this script into a directory in the system PATH. Copy or
+# symlink 'dojotimer.exe' into the same directory. Restart the shell to pick up
+# the change.
+#
+# Usage:
+# Change directory into the directory that contains or will contain the code to
+# be tested. Run:
+#
+#     dojotimer .
+#
+# The '.' at the end tells DojoTimer to track the current directory.
+
+DIR="$(dirname ${BASH_SOURCE[0]})"
+nohup mono "${DIR}/dojotimer.exe" "$@" &>/dev/null &


### PR DESCRIPTION
I have used this during Coding Dojo Brno sessions and it has been
helpful to:

1. Don't block the current shell when starting DojoTimer
2. Easily set the directory to track, instead of manually updating the
   configuration every time.

Sharing with the rest of the community, as I know folks in Dojo Rio were
interested in it (also using Linux).