### PR TITLE
Document building with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,21 @@ Run ```xbuild build.xml```
 
 You probably will have to install the most complete Mono version to do that. 
 Or at least the development packages and gtksharp-2.0.
+
+### Build on Docker
+
+If you have Docker installed, you can skip installing the Mono development tools
+and build a Linux binary using:
+
+```
+$ docker run --rm -it -v `pwd`:/src mono:4.4 bash
+# cd /src
+# xbuild build.xml
+```
+
+You will still need `mono` and `gtk-sharp2` to run the binary in the host
+system. On a Fedora workstation, install those packages by running:
+
+```
+sudo dnf install mono gtk-sharp2
+```


### PR DESCRIPTION
I have used this method in the past to avoid installing mono-devel and
all of its dependencies, so sharing it case it can be helpful to others.

Of course, pre-built binaries are awesome too.